### PR TITLE
Updating gradle, android versions

### DIFF
--- a/build.common.gradle
+++ b/build.common.gradle
@@ -77,7 +77,7 @@ android {
             // Disable debugging for release versions so it can be uploaded to Google Play.
             //debuggable true
             ndk {
-                abiFilters "armeabi-v7a", "arm64-v8a"
+                abiFilters "armeabi-v7a"
             }
         }
         debug {
@@ -85,7 +85,7 @@ android {
             jniDebuggable true
             renderscriptDebuggable true
             ndk {
-                abiFilters "armeabi-v7a", "arm64-v8a"
+                abiFilters "armeabi-v7a"
             }
         }
     }


### PR DESCRIPTION
Per First advisory on 9/20 regarding Vuforia error when using "arm64-v8a" in build.common.gradle file, removing the reference to "arm64-v8a". 
